### PR TITLE
Support for multiple devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Enter:
 - Home Assistant HTTP port
 - optional Home Assistant local IP
 
+### Managing Devices After Setup
+
+After the integration is configured, open **Settings -> Devices & services**, select **Hisense Air Conditioner**, and choose **Configure** to add, remove, or refresh devices without deleting the integration:
+
+- **Rediscover from cloud account** — re-enter app credentials to refresh LAN keys and add newly paired air conditioners
+- **Add device manually** — append another air conditioner using its LAN key
+- **Manage configured devices** — remove air conditioners from this integration (at least one must remain)
+
 ## Network Notes
 
 The air conditioner must be able to reach Home Assistant by plain HTTP on the configured port. The integration registers these local endpoints:

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ After installing, restart Home Assistant. Then open **Settings -> Devices & serv
 
 ## Supported Setup Methods
 
-### Cloud Discovery
+The integration supports two hub types. You can create multiple hubs in Home Assistant, for example one cloud account hub and several manual hubs.
 
-Use this if the device is still visible in the original mobile app.
+### Cloud account hub
+
+Use this when your air conditioner is still visible in the original mobile app. This hub is linked to one app account. Devices can only be added through cloud discovery.
 
 1. Install the integration through HACS as a custom repository.
 2. Restart Home Assistant.
@@ -91,6 +93,13 @@ Use this if the device is still visible in the original mobile app.
    - app password
 7. Select one or more discovered air conditioners to add. All discovered devices are selected by default.
 
+After setup, open the hub's **Configure** menu to:
+
+- **Rediscover devices** from the same app account and add newly paired air conditioners
+- **Remove devices** from the hub
+
+Use **Re-authenticate** on the hub to update the stored app password or app code. The username must stay the same.
+
 Advanced settings are optional and can usually stay collapsed:
 
 - device name filter, if you want discovery to look for only one exact app device name
@@ -98,9 +107,9 @@ Advanced settings are optional and can usually stay collapsed:
 - optional Home Assistant local IP if HA has multiple network interfaces or VLANs
 - device temperature unit override, if the automatic app-code detection reports the wrong unit
 
-### Manual LAN Key Setup
+### Manual hub
 
-Use this if you already know the device LAN key and key ID.
+Use this if you already know the device LAN key and key ID. Each manual hub contains exactly one air conditioner. To add another manually configured device, create another hub.
 
 Enter:
 
@@ -115,13 +124,7 @@ Enter:
 - Home Assistant HTTP port
 - optional Home Assistant local IP
 
-### Managing Devices After Setup
-
-After the integration is configured, open **Settings -> Devices & services**, select **Hisense Air Conditioner**, and choose **Configure** to add, remove, or refresh devices without deleting the integration:
-
-- **Rediscover from cloud account** — re-enter app credentials to refresh LAN keys and add newly paired air conditioners
-- **Add device manually** — append another air conditioner using its LAN key
-- **Manage configured devices** — remove air conditioners from this integration (at least one must remain)
+After setup, open the hub's **Configure** menu to edit the device's connection details.
 
 ## Network Notes
 

--- a/custom_components/hisense_aircon/__init__.py
+++ b/custom_components/hisense_aircon/__init__.py
@@ -45,5 +45,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-  """Reload when options change."""
+  """Reload when config entry data or options change."""
   await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/hisense_aircon/__init__.py
+++ b/custom_components/hisense_aircon/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import ACTIVE_CONTROLLER, DOMAIN
+from .const import DOMAIN
 from .controller import HisenseController
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,12 +38,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
   unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
   if unload_ok:
     controller = hass.data[DOMAIN].pop(entry.entry_id)
-    if hass.data[DOMAIN].get(ACTIVE_CONTROLLER) is controller:
-      hass.data[DOMAIN].pop(ACTIVE_CONTROLLER, None)
     await controller.async_stop()
   return unload_ok
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-  """Reload when config entry data or options change."""
+  """Reload when options change."""
   await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/hisense_aircon/config_flow.py
+++ b/custom_components/hisense_aircon/config_flow.py
@@ -16,7 +16,8 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import section
+from homeassistant.data_entry_flow import FlowResult, section
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     SelectSelector,
@@ -56,6 +57,10 @@ _LOGGER = logging.getLogger(__name__)
 
 _ADVANCED_SETTINGS = "advanced_settings"
 _SELECTED_DEVICES = "selected_devices"
+_RECONFIGURE_ACTION = "reconfigure_action"
+_RECONFIGURE_REDISCOVER = "rediscover"
+_RECONFIGURE_ADD_MANUAL = "add_manual"
+_RECONFIGURE_MANAGE = "manage"
 _DEFAULT_ADVANCED_SETTINGS = {
     CONF_DEVICE_NAME: "",
     CONF_LOCAL_IP: "",
@@ -93,6 +98,227 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         mode=SelectSelectorMode.DROPDOWN,
                     ))
         }),
+    )
+
+  async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Choose how to update devices on an existing config entry."""
+    if user_input is not None:
+      action = user_input[_RECONFIGURE_ACTION]
+      if action == _RECONFIGURE_REDISCOVER:
+        return await self.async_step_reconfigure_cloud()
+      if action == _RECONFIGURE_ADD_MANUAL:
+        return await self.async_step_reconfigure_manual()
+      return await self._async_step_reconfigure_manage()
+
+    return self.async_show_form(
+        step_id="reconfigure",
+        data_schema=vol.Schema({
+            vol.Required(_RECONFIGURE_ACTION):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            _RECONFIGURE_REDISCOVER,
+                            _RECONFIGURE_ADD_MANUAL,
+                            _RECONFIGURE_MANAGE,
+                        ],
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+        }),
+    )
+
+  async def _async_step_reconfigure_manage(self) -> FlowResult:
+    """Prepare device selection for removing devices from the current list."""
+    entry = self._get_reconfigure_entry()
+    self._reconfigure_entry = entry
+    self._reconfigure_candidates = list(entry.data[CONF_DEVICES])
+    self._reconfigure_preselected = [
+        device["mac_address"] for device in entry.data[CONF_DEVICES]
+    ]
+    self._reconfigure_data_updates = {}
+    return await self.async_step_reconfigure_select_devices()
+
+  async def async_step_reconfigure_cloud(
+      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Rediscover devices through the Hisense/Ayla account."""
+    entry = self._get_reconfigure_entry()
+    errors: dict[str, str] = {}
+    default_app = entry.data.get(CONF_APP, "hisense-eu")
+    if user_input is not None:
+      advanced_settings = user_input.get(_ADVANCED_SETTINGS, {})
+      try:
+        session = async_get_clientsession(self.hass)
+        discovered = await perform_discovery(
+            session,
+            user_input[CONF_APP],
+            user_input[CONF_USERNAME],
+            user_input[CONF_PASSWORD],
+            _blank_to_none(advanced_settings.get(CONF_DEVICE_NAME)),
+            False,
+        )
+      except Exception:
+        _LOGGER.exception("Hisense cloud discovery failed during reconfigure")
+        errors["base"] = "cannot_connect"
+      else:
+        if not discovered:
+          errors["base"] = "device_not_found"
+        else:
+          temp_type = advanced_settings.get(CONF_TEMP_TYPE, CONF_TEMP_TYPE_AUTO)
+          devices = [
+              _device_config_from_cloud(
+                  user_input[CONF_APP],
+                  device,
+                  _ha_temp_type(self.hass),
+                  temp_type,
+              ) for device in discovered
+          ]
+          self._reconfigure_entry = entry
+          self._reconfigure_candidates = _merge_device_lists(entry.data[CONF_DEVICES], devices)
+          self._reconfigure_preselected = [
+              device["mac_address"] for device in entry.data[CONF_DEVICES]
+          ]
+          self._reconfigure_data_updates = {
+              CONF_APP: user_input[CONF_APP],
+              CONF_LOCAL_IP: _blank_to_none(advanced_settings.get(CONF_LOCAL_IP)),
+              CONF_CALLBACK_PORT: advanced_settings.get(CONF_CALLBACK_PORT,
+                                                         DEFAULT_CALLBACK_PORT),
+              CONF_STATUS_INTERVAL: advanced_settings.get(CONF_STATUS_INTERVAL,
+                                                            DEFAULT_STATUS_INTERVAL),
+              CONF_TEMP_TYPE: temp_type,
+          }
+          return await self.async_step_reconfigure_select_devices()
+
+    return self.async_show_form(
+        step_id="reconfigure_cloud",
+        data_schema=vol.Schema({
+            vol.Required(CONF_APP, default=default_app):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=sorted(SECRET_MAP),
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+            vol.Required(CONF_USERNAME): str,
+            vol.Required(CONF_PASSWORD):
+                TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+            vol.Required(_ADVANCED_SETTINGS, default=_DEFAULT_ADVANCED_SETTINGS):
+                section(
+                    vol.Schema({
+                        vol.Optional(CONF_DEVICE_NAME, default=""): str,
+                        vol.Optional(CONF_LOCAL_IP, default=""): str,
+                        vol.Optional(CONF_CALLBACK_PORT, default=DEFAULT_CALLBACK_PORT): int,
+                        vol.Optional(CONF_STATUS_INTERVAL, default=DEFAULT_STATUS_INTERVAL): int,
+                        vol.Optional(CONF_TEMP_TYPE, default=CONF_TEMP_TYPE_AUTO):
+                            SelectSelector(
+                                SelectSelectorConfig(
+                                    options=TEMP_TYPE_OPTIONS,
+                                    mode=SelectSelectorMode.DROPDOWN,
+                                )),
+                    }),
+                    {"collapsed": True},
+                ),
+        }),
+        errors=errors,
+    )
+
+  async def async_step_reconfigure_manual(
+      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Append a manually configured device to the existing config entry."""
+    entry = self._get_reconfigure_entry()
+    errors: dict[str, str] = {}
+    default_app = entry.data.get(CONF_APP, "hisense-eu")
+    if user_input is not None:
+      try:
+        device = _device_config_from_manual(user_input)
+      except (KeyError, ValueError):
+        errors["base"] = "invalid_manual_config"
+      else:
+        existing_macs = {configured["mac_address"] for configured in entry.data[CONF_DEVICES]}
+        if device["mac_address"] in existing_macs:
+          errors["base"] = "duplicate_mac"
+        else:
+          selected_devices = list(entry.data[CONF_DEVICES]) + [device]
+          return await self._async_apply_device_selection(entry, selected_devices)
+
+    return self.async_show_form(
+        step_id="reconfigure_manual",
+        data_schema=vol.Schema({
+            vol.Required(CONF_NAME): str,
+            vol.Required(CONF_APP, default=default_app):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=sorted(SECRET_MAP),
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+            vol.Required(CONF_HOST): str,
+            vol.Required(CONF_MAC_ADDRESS): str,
+            vol.Required(CONF_LANIP_KEY): str,
+            vol.Required(CONF_LANIP_KEY_ID): int,
+            vol.Required(CONF_MODEL, default="AEH-W4E1"): str,
+            vol.Optional(CONF_SW_VERSION, default=""): str,
+            vol.Required(CONF_TEMP_TYPE, default=_ha_temp_type(self.hass)): vol.In(["C", "F"]),
+        }),
+        errors=errors,
+    )
+
+  async def async_step_reconfigure_select_devices(
+      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Select which devices to keep on an existing config entry."""
+    entry = getattr(self, "_reconfigure_entry", None)
+    if entry is None:
+      return await self.async_step_reconfigure()
+
+    candidates = self._reconfigure_candidates
+    preselected = self._reconfigure_preselected
+    data_updates = getattr(self, "_reconfigure_data_updates", {})
+
+    errors: dict[str, str] = {}
+    if user_input is not None:
+      selected = set(user_input.get(_SELECTED_DEVICES, []))
+      selected_devices = [
+          device for device in candidates if device["mac_address"] in selected
+      ]
+      if not selected_devices:
+        errors["base"] = "no_device_selected"
+      else:
+        return await self._async_apply_device_selection(
+            entry,
+            selected_devices,
+            data_updates,
+        )
+
+    return self.async_show_form(
+        step_id="reconfigure_select_devices",
+        data_schema=vol.Schema({
+            vol.Required(_SELECTED_DEVICES, default=preselected):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=[_device_option(device) for device in candidates],
+                        multiple=True,
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+        }),
+        errors=errors,
+    )
+
+  async def _async_apply_device_selection(
+      self,
+      entry: config_entries.ConfigEntry,
+      selected_devices: list[dict[str, Any]],
+      data_updates: dict[str, Any] | None = None,
+  ) -> FlowResult:
+    """Update the config entry device list and reload."""
+    old_macs = {device["mac_address"] for device in entry.data[CONF_DEVICES]}
+    new_macs = {device["mac_address"] for device in selected_devices}
+    _remove_orphaned_devices(self.hass, old_macs - new_macs)
+
+    updates: dict[str, Any] = {CONF_DEVICES: selected_devices}
+    if data_updates:
+      updates.update(data_updates)
+
+    await self.async_set_unique_id(_unique_id(selected_devices))
+    return self.async_update_reload_and_abort(
+        entry,
+        data_updates=updates,
+        title=", ".join(device["name"] for device in selected_devices),
     )
 
   async def async_step_cloud(self, user_input: dict[str, Any] | None = None):
@@ -336,6 +562,27 @@ def _normalize_mac(mac_address: str) -> str:
 def _device_option(device: dict[str, Any]) -> dict[str, str]:
   label = f"{device['name']} ({device['ip_address']})"
   return {"value": device["mac_address"], "label": label}
+
+
+def _merge_device_lists(
+    existing: list[dict[str, Any]],
+    discovered: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+  """Union device lists by MAC address; discovered cloud data wins for matches."""
+  by_mac = {device["mac_address"]: dict(device) for device in existing}
+  for device in discovered:
+    by_mac[device["mac_address"]] = device
+  return list(by_mac.values())
+
+
+def _remove_orphaned_devices(hass, removed_macs: set[str]) -> None:
+  """Remove device registry entries for devices no longer configured."""
+  if not removed_macs:
+    return
+  registry = dr.async_get(hass)
+  for mac in removed_macs:
+    if device := registry.async_get_device(identifiers={(DOMAIN, mac)}):
+      registry.async_remove_device(device.id)
 
 
 def _ha_temp_type(hass) -> str:

--- a/custom_components/hisense_aircon/config_flow.py
+++ b/custom_components/hisense_aircon/config_flow.py
@@ -8,7 +8,6 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -16,8 +15,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     UnitOfTemperature,
 )
-from homeassistant.core import callback
-from homeassistant.data_entry_flow import section
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
@@ -35,6 +34,7 @@ from .const import (
     CONF_CALLBACK_PORT,
     CONF_DEVICE_NAME,
     CONF_DEVICES,
+    CONF_HUB_TYPE,
     CONF_LANIP_KEY,
     CONF_LANIP_KEY_ID,
     CONF_LOCAL_IP,
@@ -48,6 +48,8 @@ from .const import (
     DEFAULT_CALLBACK_PORT,
     DEFAULT_STATUS_INTERVAL,
     DOMAIN,
+    HUB_TYPE_CLOUD,
+    HUB_TYPE_MANUAL,
     SETUP_METHOD_CLOUD,
     SETUP_METHOD_MANUAL,
     TEMP_TYPE_OPTIONS,
@@ -60,8 +62,7 @@ _ADVANCED_SETTINGS = "advanced_settings"
 _SELECTED_DEVICES = "selected_devices"
 _RECONFIGURE_ACTION = "reconfigure_action"
 _RECONFIGURE_REDISCOVER = "rediscover"
-_RECONFIGURE_ADD_MANUAL = "add_manual"
-_RECONFIGURE_MANAGE = "manage"
+_RECONFIGURE_REMOVE = "remove_devices"
 _DEFAULT_ADVANCED_SETTINGS = {
     CONF_DEVICE_NAME: "",
     CONF_LOCAL_IP: "",
@@ -74,15 +75,50 @@ _DEFAULT_ADVANCED_SETTINGS = {
 class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
   """Handle a config flow for Hisense Air Conditioner."""
 
-  VERSION = 1
+  VERSION = 2
+
+  def __init__(self) -> None:
+    self._cloud_setup: dict[str, Any] | None = None
+    self._device_candidates: list[dict[str, Any]] | None = None
+    self._preselected_macs: list[str] | None = None
 
   @staticmethod
   @callback
   def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> HisenseOptionsFlow:
     """Return the options flow."""
-    return HisenseOptionsFlow()
+    return HisenseOptionsFlow(config_entry)
 
-  async def async_step_user(self, user_input: dict[str, Any] | None = None):
+  @staticmethod
+  @callback
+  def async_migrate_entry(hass: HomeAssistant, entry: config_entries.ConfigEntry) -> bool:
+    """Migrate config entry to the latest version."""
+    if entry.version > 2:
+      return False
+
+    if entry.version == 1:
+      data = dict(entry.data)
+      devices = data.get(CONF_DEVICES, [])
+      if CONF_USERNAME in data:
+        hub_type = HUB_TYPE_CLOUD
+        unique_id = _cloud_unique_id(data[CONF_APP], data[CONF_USERNAME])
+      elif len(devices) == 1:
+        hub_type = HUB_TYPE_MANUAL
+        unique_id = _manual_unique_id(devices[0]["mac_address"])
+      else:
+        hub_type = HUB_TYPE_CLOUD
+        unique_id = entry.unique_id
+      data[CONF_HUB_TYPE] = hub_type
+      data[CONF_SETUP_METHOD] = hub_type
+      hass.config_entries.async_update_entry(
+          entry,
+          data=data,
+          unique_id=unique_id,
+          version=2,
+      )
+
+    return True
+
+  async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
     """Choose setup method."""
     if user_input is not None:
       if user_input[CONF_SETUP_METHOD] == SETUP_METHOD_MANUAL:
@@ -101,228 +137,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }),
     )
 
-  async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-    """Choose how to update devices on an existing config entry."""
-    if user_input is not None:
-      action = user_input[_RECONFIGURE_ACTION]
-      if action == _RECONFIGURE_REDISCOVER:
-        return await self.async_step_reconfigure_cloud()
-      if action == _RECONFIGURE_ADD_MANUAL:
-        return await self.async_step_reconfigure_manual()
-      return await self._async_step_reconfigure_manage()
-
-    return self.async_show_form(
-        step_id="reconfigure",
-        data_schema=vol.Schema({
-            vol.Required(_RECONFIGURE_ACTION):
-                SelectSelector(
-                    SelectSelectorConfig(
-                        options=[
-                            _RECONFIGURE_REDISCOVER,
-                            _RECONFIGURE_ADD_MANUAL,
-                            _RECONFIGURE_MANAGE,
-                        ],
-                        mode=SelectSelectorMode.DROPDOWN,
-                    )),
-        }),
-    )
-
-  async def _async_step_reconfigure_manage(self) -> ConfigFlowResult:
-    """Prepare device selection for removing devices from the current list."""
-    entry = self._get_reconfigure_entry()
-    self._reconfigure_entry = entry
-    self._reconfigure_candidates = list(entry.data[CONF_DEVICES])
-    self._reconfigure_preselected = [
-        device["mac_address"] for device in entry.data[CONF_DEVICES]
-    ]
-    self._reconfigure_data_updates = {}
-    return await self.async_step_reconfigure_select_devices()
-
-  async def async_step_reconfigure_cloud(
-      self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-    """Rediscover devices through the Hisense/Ayla account."""
-    entry = self._get_reconfigure_entry()
-    errors: dict[str, str] = {}
-    default_app = entry.data.get(CONF_APP, "hisense-eu")
-    if user_input is not None:
-      advanced_settings = user_input.get(_ADVANCED_SETTINGS, {})
-      try:
-        session = async_get_clientsession(self.hass)
-        discovered = await perform_discovery(
-            session,
-            user_input[CONF_APP],
-            user_input[CONF_USERNAME],
-            user_input[CONF_PASSWORD],
-            _blank_to_none(advanced_settings.get(CONF_DEVICE_NAME)),
-            False,
-        )
-      except Exception:
-        _LOGGER.exception("Hisense cloud discovery failed during reconfigure")
-        errors["base"] = "cannot_connect"
-      else:
-        if not discovered:
-          errors["base"] = "device_not_found"
-        else:
-          temp_type = advanced_settings.get(CONF_TEMP_TYPE, CONF_TEMP_TYPE_AUTO)
-          devices = [
-              _device_config_from_cloud(
-                  user_input[CONF_APP],
-                  device,
-                  _ha_temp_type(self.hass),
-                  temp_type,
-              ) for device in discovered
-          ]
-          self._reconfigure_entry = entry
-          self._reconfigure_candidates = _merge_device_lists(entry.data[CONF_DEVICES], devices)
-          self._reconfigure_preselected = [
-              device["mac_address"] for device in entry.data[CONF_DEVICES]
-          ]
-          self._reconfigure_data_updates = {
-              CONF_APP: user_input[CONF_APP],
-              CONF_LOCAL_IP: _blank_to_none(advanced_settings.get(CONF_LOCAL_IP)),
-              CONF_CALLBACK_PORT: advanced_settings.get(CONF_CALLBACK_PORT,
-                                                         DEFAULT_CALLBACK_PORT),
-              CONF_STATUS_INTERVAL: advanced_settings.get(CONF_STATUS_INTERVAL,
-                                                            DEFAULT_STATUS_INTERVAL),
-              CONF_TEMP_TYPE: temp_type,
-          }
-          return await self.async_step_reconfigure_select_devices()
-
-    return self.async_show_form(
-        step_id="reconfigure_cloud",
-        data_schema=vol.Schema({
-            vol.Required(CONF_APP, default=default_app):
-                SelectSelector(
-                    SelectSelectorConfig(
-                        options=sorted(SECRET_MAP),
-                        mode=SelectSelectorMode.DROPDOWN,
-                    )),
-            vol.Required(CONF_USERNAME): str,
-            vol.Required(CONF_PASSWORD):
-                TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
-            vol.Required(_ADVANCED_SETTINGS, default=_DEFAULT_ADVANCED_SETTINGS):
-                section(
-                    vol.Schema({
-                        vol.Optional(CONF_DEVICE_NAME, default=""): str,
-                        vol.Optional(CONF_LOCAL_IP, default=""): str,
-                        vol.Optional(CONF_CALLBACK_PORT, default=DEFAULT_CALLBACK_PORT): int,
-                        vol.Optional(CONF_STATUS_INTERVAL, default=DEFAULT_STATUS_INTERVAL): int,
-                        vol.Optional(CONF_TEMP_TYPE, default=CONF_TEMP_TYPE_AUTO):
-                            SelectSelector(
-                                SelectSelectorConfig(
-                                    options=TEMP_TYPE_OPTIONS,
-                                    mode=SelectSelectorMode.DROPDOWN,
-                                )),
-                    }),
-                    {"collapsed": True},
-                ),
-        }),
-        errors=errors,
-    )
-
-  async def async_step_reconfigure_manual(
-      self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-    """Append a manually configured device to the existing config entry."""
-    entry = self._get_reconfigure_entry()
-    errors: dict[str, str] = {}
-    default_app = entry.data.get(CONF_APP, "hisense-eu")
-    if user_input is not None:
-      try:
-        device = _device_config_from_manual(user_input)
-      except (KeyError, ValueError):
-        errors["base"] = "invalid_manual_config"
-      else:
-        existing_macs = {configured["mac_address"] for configured in entry.data[CONF_DEVICES]}
-        if device["mac_address"] in existing_macs:
-          errors["base"] = "duplicate_mac"
-        else:
-          selected_devices = list(entry.data[CONF_DEVICES]) + [device]
-          return await self._async_apply_device_selection(entry, selected_devices)
-
-    return self.async_show_form(
-        step_id="reconfigure_manual",
-        data_schema=vol.Schema({
-            vol.Required(CONF_NAME): str,
-            vol.Required(CONF_APP, default=default_app):
-                SelectSelector(
-                    SelectSelectorConfig(
-                        options=sorted(SECRET_MAP),
-                        mode=SelectSelectorMode.DROPDOWN,
-                    )),
-            vol.Required(CONF_HOST): str,
-            vol.Required(CONF_MAC_ADDRESS): str,
-            vol.Required(CONF_LANIP_KEY): str,
-            vol.Required(CONF_LANIP_KEY_ID): int,
-            vol.Required(CONF_MODEL, default="AEH-W4E1"): str,
-            vol.Optional(CONF_SW_VERSION, default=""): str,
-            vol.Required(CONF_TEMP_TYPE, default=_ha_temp_type(self.hass)): vol.In(["C", "F"]),
-        }),
-        errors=errors,
-    )
-
-  async def async_step_reconfigure_select_devices(
-      self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-    """Select which devices to keep on an existing config entry."""
-    entry = getattr(self, "_reconfigure_entry", None)
-    if entry is None:
-      return await self.async_step_reconfigure()
-
-    candidates = self._reconfigure_candidates
-    preselected = self._reconfigure_preselected
-    data_updates = getattr(self, "_reconfigure_data_updates", {})
-
-    errors: dict[str, str] = {}
-    if user_input is not None:
-      selected = set(user_input.get(_SELECTED_DEVICES, []))
-      selected_devices = [
-          device for device in candidates if device["mac_address"] in selected
-      ]
-      if not selected_devices:
-        errors["base"] = "no_device_selected"
-      else:
-        return await self._async_apply_device_selection(
-            entry,
-            selected_devices,
-            data_updates,
-        )
-
-    return self.async_show_form(
-        step_id="reconfigure_select_devices",
-        data_schema=vol.Schema({
-            vol.Required(_SELECTED_DEVICES, default=preselected):
-                SelectSelector(
-                    SelectSelectorConfig(
-                        options=[_device_option(device) for device in candidates],
-                        multiple=True,
-                        mode=SelectSelectorMode.DROPDOWN,
-                    )),
-        }),
-        errors=errors,
-    )
-
-  async def _async_apply_device_selection(
-      self,
-      entry: config_entries.ConfigEntry,
-      selected_devices: list[dict[str, Any]],
-      data_updates: dict[str, Any] | None = None,
-  ) -> ConfigFlowResult:
-    """Update the config entry device list; the update listener reloads."""
-    old_macs = {device["mac_address"] for device in entry.data[CONF_DEVICES]}
-    new_macs = {device["mac_address"] for device in selected_devices}
-    _remove_orphaned_devices(self.hass, old_macs - new_macs)
-
-    updates: dict[str, Any] = {CONF_DEVICES: selected_devices}
-    if data_updates:
-      updates.update(data_updates)
-
-    return self.async_update_and_abort(
-        entry,
-        unique_id=_unique_id(selected_devices),
-        data_updates=updates,
-        title=", ".join(device["name"] for device in selected_devices),
-    )
-
-  async def async_step_cloud(self, user_input: dict[str, Any] | None = None):
+  async def async_step_cloud(self, user_input: dict[str, Any] | None = None) -> FlowResult:
     """Discover devices through the Hisense/Ayla account."""
     errors: dict[str, str] = {}
     if user_input is not None:
@@ -354,7 +169,11 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
               ) for device in discovered
           ]
           self._cloud_setup = {
+              CONF_HUB_TYPE: HUB_TYPE_CLOUD,
+              CONF_SETUP_METHOD: SETUP_METHOD_CLOUD,
               CONF_APP: user_input[CONF_APP],
+              CONF_USERNAME: user_input[CONF_USERNAME],
+              CONF_PASSWORD: user_input[CONF_PASSWORD],
               CONF_DEVICES: devices,
               CONF_LOCAL_IP: _blank_to_none(advanced_settings.get(CONF_LOCAL_IP)),
               CONF_CALLBACK_PORT: advanced_settings.get(CONF_CALLBACK_PORT,
@@ -397,9 +216,9 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors=errors,
     )
 
-  async def async_step_select_devices(self, user_input: dict[str, Any] | None = None):
+  async def async_step_select_devices(self, user_input: dict[str, Any] | None = None) -> FlowResult:
     """Select one or more discovered devices."""
-    cloud_setup = getattr(self, "_cloud_setup", None)
+    cloud_setup = self._cloud_setup
     if cloud_setup is None:
       return await self.async_step_cloud()
 
@@ -410,12 +229,15 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
       selected_devices = [device for device in devices if device["mac_address"] in selected]
       if not selected_devices:
         errors["base"] = "no_device_selected"
+      elif conflicting := _conflicting_macs(self.hass, selected_devices):
+        errors["base"] = "duplicate_mac"
+        _LOGGER.warning("Device MAC(s) already configured: %s", conflicting)
       else:
-        await self.async_set_unique_id(_unique_id(selected_devices))
+        await self.async_set_unique_id(
+            _cloud_unique_id(cloud_setup[CONF_APP], cloud_setup[CONF_USERNAME]))
         self._abort_if_unique_id_configured()
-        title = ", ".join(device["name"] for device in selected_devices)
         return self.async_create_entry(
-            title=title,
+            title=_cloud_entry_title(cloud_setup),
             data={
                 **cloud_setup,
                 CONF_DEVICES: selected_devices,
@@ -439,7 +261,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors=errors,
     )
 
-  async def async_step_manual(self, user_input: dict[str, Any] | None = None):
+  async def async_step_manual(self, user_input: dict[str, Any] | None = None) -> FlowResult:
     """Set up a device from an existing LAN key."""
     errors: dict[str, str] = {}
     if user_input is not None:
@@ -448,19 +270,24 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
       except (KeyError, ValueError):
         errors["base"] = "invalid_manual_config"
       else:
-        await self.async_set_unique_id(_unique_id([device]))
-        self._abort_if_unique_id_configured()
-        return self.async_create_entry(
-            title=device["name"],
-            data={
-                CONF_APP: device["app"],
-                CONF_DEVICES: [device],
-                CONF_LOCAL_IP: _blank_to_none(user_input.get(CONF_LOCAL_IP)),
-                CONF_CALLBACK_PORT: user_input[CONF_CALLBACK_PORT],
-                CONF_STATUS_INTERVAL: user_input[CONF_STATUS_INTERVAL],
-                CONF_TEMP_TYPE: user_input[CONF_TEMP_TYPE],
-            },
-        )
+        if _mac_in_use(self.hass, device["mac_address"]):
+          errors["base"] = "duplicate_mac"
+        else:
+          await self.async_set_unique_id(_manual_unique_id(device["mac_address"]))
+          self._abort_if_unique_id_configured()
+          return self.async_create_entry(
+              title=device["name"],
+              data={
+                  CONF_HUB_TYPE: HUB_TYPE_MANUAL,
+                  CONF_SETUP_METHOD: SETUP_METHOD_MANUAL,
+                  CONF_APP: device["app"],
+                  CONF_DEVICES: [device],
+                  CONF_LOCAL_IP: _blank_to_none(user_input.get(CONF_LOCAL_IP)),
+                  CONF_CALLBACK_PORT: user_input[CONF_CALLBACK_PORT],
+                  CONF_STATUS_INTERVAL: user_input[CONF_STATUS_INTERVAL],
+                  CONF_TEMP_TYPE: user_input[CONF_TEMP_TYPE],
+              },
+          )
 
     return self.async_show_form(
         step_id="manual",
@@ -486,11 +313,334 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors=errors,
     )
 
+  async def async_step_reconfigure(
+      self, user_input: dict[str, Any] | None = None, errors: dict[str, str] | None = None
+  ) -> FlowResult:
+    """Reconfigure an existing hub."""
+    entry = self._get_reconfigure_entry()
+    if entry.data.get(CONF_HUB_TYPE) == HUB_TYPE_MANUAL:
+      return await self.async_step_reconfigure_manual()
+
+    if user_input is not None:
+      action = user_input[_RECONFIGURE_ACTION]
+      if action == _RECONFIGURE_REDISCOVER:
+        return await self.async_step_reconfigure_rediscover()
+      return await self.async_step_reconfigure_remove_devices()
+
+    return self.async_show_form(
+        step_id="reconfigure",
+        data_schema=vol.Schema({
+            vol.Required(_RECONFIGURE_ACTION):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            {
+                                "value": _RECONFIGURE_REDISCOVER,
+                                "label": "Rediscover devices from cloud account",
+                            },
+                            {
+                                "value": _RECONFIGURE_REMOVE,
+                                "label": "Remove configured devices",
+                            },
+                        ],
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+        }),
+        errors=errors or {},
+    )
+
+  async def async_step_reconfigure_rediscover(
+      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Rediscover devices for a cloud hub."""
+    entry = self._get_reconfigure_entry()
+    errors: dict[str, str] = {}
+
+    if CONF_USERNAME not in entry.data or CONF_PASSWORD not in entry.data:
+      return await self.async_step_reauth()
+
+    if user_input is None:
+      try:
+        session = async_get_clientsession(self.hass)
+        discovered = await perform_discovery(
+            session,
+            entry.data[CONF_APP],
+            entry.data[CONF_USERNAME],
+            entry.data[CONF_PASSWORD],
+            None,
+            False,
+        )
+      except Exception:
+        _LOGGER.exception("Hisense cloud rediscovery failed")
+        errors["base"] = "cannot_connect"
+      else:
+        if not discovered:
+          errors["base"] = "device_not_found"
+        else:
+          temp_type = entry.data.get(CONF_TEMP_TYPE, CONF_TEMP_TYPE_AUTO)
+          cloud_devices = [
+              _device_config_from_cloud(
+                  entry.data[CONF_APP],
+                  device,
+                  _ha_temp_type(self.hass),
+                  temp_type,
+              ) for device in discovered
+          ]
+          self._device_candidates = _merge_device_lists(
+              entry.data.get(CONF_DEVICES, []),
+              cloud_devices,
+          )
+          self._preselected_macs = [
+              device["mac_address"] for device in entry.data.get(CONF_DEVICES, [])
+          ]
+          return await self.async_step_reconfigure_select_devices()
+
+      return await self.async_step_reconfigure(errors=errors)
+
+    return await self.async_step_reconfigure_select_devices(user_input)
+
+  async def async_step_reconfigure_select_devices(
+      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Select devices after cloud rediscovery."""
+    entry = self._get_reconfigure_entry()
+    candidates = self._device_candidates
+    if candidates is None:
+      return await self.async_step_reconfigure_rediscover()
+
+    errors: dict[str, str] = {}
+    preselected = self._preselected_macs or [
+        device["mac_address"] for device in entry.data.get(CONF_DEVICES, [])
+    ]
+
+    if user_input is not None:
+      selected = set(user_input.get(_SELECTED_DEVICES, []))
+      selected_devices = [device for device in candidates if device["mac_address"] in selected]
+      if not selected_devices:
+        errors["base"] = "no_device_selected"
+      elif conflicting := _conflicting_macs(
+          self.hass,
+          selected_devices,
+          exclude_entry_id=entry.entry_id,
+      ):
+        errors["base"] = "duplicate_mac"
+        _LOGGER.warning("Device MAC(s) already configured: %s", conflicting)
+      else:
+        old_macs = {device["mac_address"] for device in entry.data.get(CONF_DEVICES, [])}
+        new_macs = {device["mac_address"] for device in selected_devices}
+        _remove_orphaned_devices(self.hass, old_macs, new_macs)
+        return self.async_update_reload_and_abort(
+            entry,
+            data_updates={CONF_DEVICES: selected_devices},
+            title=_cloud_entry_title(entry.data),
+        )
+
+    return self.async_show_form(
+        step_id="reconfigure_select_devices",
+        data_schema=vol.Schema({
+            vol.Required(
+                _SELECTED_DEVICES,
+                default=preselected,
+            ):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=[_device_option(device) for device in candidates],
+                        multiple=True,
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+        }),
+        errors=errors,
+    )
+
+  async def async_step_reconfigure_remove_devices(
+      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Remove devices from a cloud hub."""
+    entry = self._get_reconfigure_entry()
+    devices = entry.data.get(CONF_DEVICES, [])
+    errors: dict[str, str] = {}
+
+    if user_input is not None:
+      selected = set(user_input.get(_SELECTED_DEVICES, []))
+      selected_devices = [device for device in devices if device["mac_address"] in selected]
+      if not selected_devices:
+        errors["base"] = "no_device_selected"
+      else:
+        old_macs = {device["mac_address"] for device in devices}
+        new_macs = {device["mac_address"] for device in selected_devices}
+        _remove_orphaned_devices(self.hass, old_macs, new_macs)
+        return self.async_update_reload_and_abort(
+            entry,
+            data_updates={CONF_DEVICES: selected_devices},
+            title=_cloud_entry_title(entry.data),
+        )
+
+    return self.async_show_form(
+        step_id="reconfigure_remove_devices",
+        data_schema=vol.Schema({
+            vol.Required(
+                _SELECTED_DEVICES,
+                default=[device["mac_address"] for device in devices],
+            ):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=[_device_option(device) for device in devices],
+                        multiple=True,
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+        }),
+        errors=errors,
+    )
+
+  async def async_step_reconfigure_manual(
+      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Edit the single device on a manual hub."""
+    entry = self._get_reconfigure_entry()
+    devices = entry.data.get(CONF_DEVICES, [])
+    if len(devices) != 1:
+      return self.async_abort(reason="manual_single_device")
+
+    current = devices[0]
+    errors: dict[str, str] = {}
+
+    if user_input is not None:
+      try:
+        device = _device_config_from_manual(user_input)
+      except (KeyError, ValueError):
+        errors["base"] = "invalid_manual_config"
+      else:
+        if (
+            device["mac_address"] != current["mac_address"]
+            and _mac_in_use(self.hass, device["mac_address"], exclude_entry_id=entry.entry_id)
+        ):
+          errors["base"] = "duplicate_mac"
+        else:
+          old_macs = {current["mac_address"]}
+          new_macs = {device["mac_address"]}
+          _remove_orphaned_devices(self.hass, old_macs, new_macs)
+          updates: dict[str, Any] = {
+              CONF_DEVICES: [device],
+              CONF_APP: device["app"],
+              CONF_LOCAL_IP: _blank_to_none(user_input.get(CONF_LOCAL_IP)),
+              CONF_CALLBACK_PORT: user_input[CONF_CALLBACK_PORT],
+              CONF_STATUS_INTERVAL: user_input[CONF_STATUS_INTERVAL],
+              CONF_TEMP_TYPE: user_input[CONF_TEMP_TYPE],
+          }
+          reload_kwargs: dict[str, Any] = {
+              "data_updates": updates,
+              "title": device["name"],
+          }
+          if device["mac_address"] != current["mac_address"]:
+            await self.async_set_unique_id(_manual_unique_id(device["mac_address"]))
+            self._abort_if_unique_id_configured()
+          return self.async_update_reload_and_abort(entry, **reload_kwargs)
+
+    return self.async_show_form(
+        step_id="reconfigure_manual",
+        data_schema=vol.Schema({
+            vol.Required(CONF_NAME, default=current["name"]): str,
+            vol.Required(CONF_APP, default=current["app"]):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=sorted(SECRET_MAP),
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+            vol.Required(CONF_HOST, default=current["ip_address"]): str,
+            vol.Required(CONF_MAC_ADDRESS, default=current["mac_address"]): str,
+            vol.Required(CONF_LANIP_KEY, default=current["lanip_key"]): str,
+            vol.Required(CONF_LANIP_KEY_ID, default=current["lanip_key_id"]): int,
+            vol.Required(CONF_MODEL, default=current.get("model", "AEH-W4E1")): str,
+            vol.Optional(CONF_SW_VERSION, default=current.get("sw_version") or ""): str,
+            vol.Required(CONF_TEMP_TYPE, default=current["temp_type"]): vol.In(["C", "F"]),
+            vol.Optional(
+                CONF_LOCAL_IP,
+                default=entry.options.get(
+                    CONF_LOCAL_IP,
+                    entry.data.get(CONF_LOCAL_IP) or "",
+                ),
+            ):
+                str,
+            vol.Required(
+                CONF_CALLBACK_PORT,
+                default=entry.options.get(
+                    CONF_CALLBACK_PORT,
+                    entry.data.get(CONF_CALLBACK_PORT, DEFAULT_CALLBACK_PORT),
+                ),
+            ):
+                int,
+            vol.Required(
+                CONF_STATUS_INTERVAL,
+                default=entry.options.get(
+                    CONF_STATUS_INTERVAL,
+                    entry.data.get(CONF_STATUS_INTERVAL, DEFAULT_STATUS_INTERVAL),
+                ),
+            ):
+                int,
+        }),
+        errors=errors,
+    )
+
+  async def async_step_reauth(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    """Update cloud account credentials."""
+    entry = self._get_reauth_entry()
+    errors: dict[str, str] = {}
+
+    if user_input is not None:
+      username = user_input[CONF_USERNAME].strip()
+      if username.lower() != entry.data.get(CONF_USERNAME, "").lower():
+        errors["base"] = "account_mismatch"
+      else:
+        try:
+          session = async_get_clientsession(self.hass)
+          await perform_discovery(
+              session,
+              user_input[CONF_APP],
+              username,
+              user_input[CONF_PASSWORD],
+              None,
+              False,
+          )
+        except Exception:
+          _LOGGER.exception("Hisense cloud reauthentication failed")
+          errors["base"] = "cannot_connect"
+        else:
+          await self.async_set_unique_id(_cloud_unique_id(user_input[CONF_APP], username))
+          self._abort_if_unique_id_mismatch()
+          return self.async_update_reload_and_abort(
+              entry,
+              data_updates={
+                  CONF_APP: user_input[CONF_APP],
+                  CONF_USERNAME: username,
+                  CONF_PASSWORD: user_input[CONF_PASSWORD],
+              },
+              title=_cloud_entry_title({
+                  CONF_APP: user_input[CONF_APP],
+                  CONF_USERNAME: username,
+              }),
+          )
+
+    defaults = entry.data
+    return self.async_show_form(
+        step_id="reauth",
+        data_schema=vol.Schema({
+            vol.Required(CONF_APP, default=defaults.get(CONF_APP, "hisense-eu")):
+                SelectSelector(
+                    SelectSelectorConfig(
+                        options=sorted(SECRET_MAP),
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )),
+            vol.Required(CONF_USERNAME, default=defaults.get(CONF_USERNAME, "")): str,
+            vol.Required(CONF_PASSWORD):
+                TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+        }),
+        errors=errors,
+    )
+
 
 class HisenseOptionsFlow(config_entries.OptionsFlow):
   """Handle Hisense options."""
 
-  async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+  def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    self._entry = config_entry
+
+  async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
     """Manage runtime options."""
     if user_input is not None:
       return self.async_create_entry(
@@ -508,33 +658,33 @@ class HisenseOptionsFlow(config_entries.OptionsFlow):
         data_schema=vol.Schema({
             vol.Optional(
                 CONF_LOCAL_IP,
-                default=self.config_entry.options.get(
+                default=self._entry.options.get(
                     CONF_LOCAL_IP,
-                    self.config_entry.data.get(CONF_LOCAL_IP) or "",
+                    self._entry.data.get(CONF_LOCAL_IP) or "",
                 ),
             ):
                 str,
             vol.Required(
                 CONF_CALLBACK_PORT,
-                default=self.config_entry.options.get(
+                default=self._entry.options.get(
                     CONF_CALLBACK_PORT,
-                    self.config_entry.data.get(CONF_CALLBACK_PORT, DEFAULT_CALLBACK_PORT),
+                    self._entry.data.get(CONF_CALLBACK_PORT, DEFAULT_CALLBACK_PORT),
                 ),
             ):
                 int,
             vol.Required(
                 CONF_STATUS_INTERVAL,
-                default=self.config_entry.options.get(
+                default=self._entry.options.get(
                     CONF_STATUS_INTERVAL,
-                    self.config_entry.data.get(CONF_STATUS_INTERVAL, DEFAULT_STATUS_INTERVAL),
+                    self._entry.data.get(CONF_STATUS_INTERVAL, DEFAULT_STATUS_INTERVAL),
                 ),
             ):
                 int,
             vol.Required(
                 CONF_TEMP_TYPE,
-                default=self.config_entry.options.get(
+                default=self._entry.options.get(
                     CONF_TEMP_TYPE,
-                    self.config_entry.data.get(CONF_TEMP_TYPE, CONF_TEMP_TYPE_AUTO),
+                    self._entry.data.get(CONF_TEMP_TYPE, CONF_TEMP_TYPE_AUTO),
                 ),
             ):
                 SelectSelector(
@@ -562,30 +712,84 @@ def _device_option(device: dict[str, Any]) -> dict[str, str]:
   return {"value": device["mac_address"], "label": label}
 
 
+def _ha_temp_type(hass: HomeAssistant) -> str:
+  """Return the Home Assistant configured temperature unit as Hisense temp_type."""
+  return "F" if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT else "C"
+
+
+def _cloud_unique_id(app: str, username: str) -> str:
+  return f"{app}:{username.strip().lower()}"
+
+
+def _manual_unique_id(mac_address: str) -> str:
+  return f"manual:{_normalize_mac(mac_address)}"
+
+
+def _cloud_entry_title(data: dict[str, Any]) -> str:
+  return f"{data[CONF_APP]} — {data[CONF_USERNAME]}"
+
+
+def _configured_macs(
+    hass: HomeAssistant,
+    *,
+    exclude_entry_id: str | None = None,
+) -> set[str]:
+  macs: set[str] = set()
+  for entry in hass.config_entries.async_entries(DOMAIN):
+    if entry.entry_id == exclude_entry_id:
+      continue
+    for device in entry.data.get(CONF_DEVICES, []):
+      macs.add(_normalize_mac(device["mac_address"]))
+  return macs
+
+
+def _mac_in_use(
+    hass: HomeAssistant,
+    mac_address: str,
+    *,
+    exclude_entry_id: str | None = None,
+) -> bool:
+  return _normalize_mac(mac_address) in _configured_macs(
+      hass, exclude_entry_id=exclude_entry_id)
+
+
+def _conflicting_macs(
+    hass: HomeAssistant,
+    devices: list[dict[str, Any]],
+    *,
+    exclude_entry_id: str | None = None,
+) -> list[str]:
+  configured = _configured_macs(hass, exclude_entry_id=exclude_entry_id)
+  return [
+      device["mac_address"] for device in devices
+      if _normalize_mac(device["mac_address"]) in configured
+  ]
+
+
 def _merge_device_lists(
     existing: list[dict[str, Any]],
     discovered: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-  """Union device lists by MAC address; discovered cloud data wins for matches."""
-  by_mac = {device["mac_address"]: dict(device) for device in existing}
+  """Union device lists by MAC address; discovered cloud data wins."""
+  by_mac = {device["mac_address"]: device for device in existing}
   for device in discovered:
     by_mac[device["mac_address"]] = device
   return list(by_mac.values())
 
 
-def _remove_orphaned_devices(hass, removed_macs: set[str]) -> None:
-  """Remove device registry entries for devices no longer configured."""
+def _remove_orphaned_devices(
+    hass: HomeAssistant,
+    old_macs: set[str],
+    new_macs: set[str],
+) -> None:
+  """Remove device registry entries for MACs no longer configured."""
+  removed_macs = old_macs - new_macs
   if not removed_macs:
     return
-  registry = dr.async_get(hass)
+  device_registry = dr.async_get(hass)
   for mac in removed_macs:
-    if device := registry.async_get_device(identifiers={(DOMAIN, mac)}):
-      registry.async_remove_device(device.id)
-
-
-def _ha_temp_type(hass) -> str:
-  """Return the Home Assistant configured temperature unit as Hisense temp_type."""
-  return "F" if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT else "C"
+    if device := device_registry.async_get_device(identifiers={(DOMAIN, mac)}):
+      device_registry.async_remove_device(device.id)
 
 
 def _device_config_from_cloud(
@@ -624,7 +828,3 @@ def _device_config_from_manual(user_input: dict[str, Any]) -> dict[str, Any]:
       "lanip_key": user_input[CONF_LANIP_KEY],
       "lanip_key_id": user_input[CONF_LANIP_KEY_ID],
   }
-
-
-def _unique_id(devices: list[dict[str, Any]]) -> str:
-  return ",".join(sorted(device["mac_address"] for device in devices))

--- a/custom_components/hisense_aircon/config_flow.py
+++ b/custom_components/hisense_aircon/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -16,7 +17,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult, section
+from homeassistant.data_entry_flow import section
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
@@ -79,7 +80,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
   @callback
   def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> HisenseOptionsFlow:
     """Return the options flow."""
-    return HisenseOptionsFlow(config_entry)
+    return HisenseOptionsFlow()
 
   async def async_step_user(self, user_input: dict[str, Any] | None = None):
     """Choose setup method."""
@@ -100,7 +101,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }),
     )
 
-  async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+  async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
     """Choose how to update devices on an existing config entry."""
     if user_input is not None:
       action = user_input[_RECONFIGURE_ACTION]
@@ -126,7 +127,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }),
     )
 
-  async def _async_step_reconfigure_manage(self) -> FlowResult:
+  async def _async_step_reconfigure_manage(self) -> ConfigFlowResult:
     """Prepare device selection for removing devices from the current list."""
     entry = self._get_reconfigure_entry()
     self._reconfigure_entry = entry
@@ -138,7 +139,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     return await self.async_step_reconfigure_select_devices()
 
   async def async_step_reconfigure_cloud(
-      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+      self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
     """Rediscover devices through the Hisense/Ayla account."""
     entry = self._get_reconfigure_entry()
     errors: dict[str, str] = {}
@@ -220,7 +221,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     )
 
   async def async_step_reconfigure_manual(
-      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+      self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
     """Append a manually configured device to the existing config entry."""
     entry = self._get_reconfigure_entry()
     errors: dict[str, str] = {}
@@ -260,7 +261,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     )
 
   async def async_step_reconfigure_select_devices(
-      self, user_input: dict[str, Any] | None = None) -> FlowResult:
+      self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
     """Select which devices to keep on an existing config entry."""
     entry = getattr(self, "_reconfigure_entry", None)
     if entry is None:
@@ -304,8 +305,8 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
       entry: config_entries.ConfigEntry,
       selected_devices: list[dict[str, Any]],
       data_updates: dict[str, Any] | None = None,
-  ) -> FlowResult:
-    """Update the config entry device list and reload."""
+  ) -> ConfigFlowResult:
+    """Update the config entry device list; the update listener reloads."""
     old_macs = {device["mac_address"] for device in entry.data[CONF_DEVICES]}
     new_macs = {device["mac_address"] for device in selected_devices}
     _remove_orphaned_devices(self.hass, old_macs - new_macs)
@@ -314,9 +315,9 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     if data_updates:
       updates.update(data_updates)
 
-    await self.async_set_unique_id(_unique_id(selected_devices))
-    return self.async_update_reload_and_abort(
+    return self.async_update_and_abort(
         entry,
+        unique_id=_unique_id(selected_devices),
         data_updates=updates,
         title=", ".join(device["name"] for device in selected_devices),
     )
@@ -489,10 +490,7 @@ class HisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class HisenseOptionsFlow(config_entries.OptionsFlow):
   """Handle Hisense options."""
 
-  def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-    self._entry = config_entry
-
-  async def async_step_init(self, user_input: dict[str, Any] | None = None):
+  async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
     """Manage runtime options."""
     if user_input is not None:
       return self.async_create_entry(
@@ -510,33 +508,33 @@ class HisenseOptionsFlow(config_entries.OptionsFlow):
         data_schema=vol.Schema({
             vol.Optional(
                 CONF_LOCAL_IP,
-                default=self._entry.options.get(
+                default=self.config_entry.options.get(
                     CONF_LOCAL_IP,
-                    self._entry.data.get(CONF_LOCAL_IP) or "",
+                    self.config_entry.data.get(CONF_LOCAL_IP) or "",
                 ),
             ):
                 str,
             vol.Required(
                 CONF_CALLBACK_PORT,
-                default=self._entry.options.get(
+                default=self.config_entry.options.get(
                     CONF_CALLBACK_PORT,
-                    self._entry.data.get(CONF_CALLBACK_PORT, DEFAULT_CALLBACK_PORT),
+                    self.config_entry.data.get(CONF_CALLBACK_PORT, DEFAULT_CALLBACK_PORT),
                 ),
             ):
                 int,
             vol.Required(
                 CONF_STATUS_INTERVAL,
-                default=self._entry.options.get(
+                default=self.config_entry.options.get(
                     CONF_STATUS_INTERVAL,
-                    self._entry.data.get(CONF_STATUS_INTERVAL, DEFAULT_STATUS_INTERVAL),
+                    self.config_entry.data.get(CONF_STATUS_INTERVAL, DEFAULT_STATUS_INTERVAL),
                 ),
             ):
                 int,
             vol.Required(
                 CONF_TEMP_TYPE,
-                default=self._entry.options.get(
+                default=self.config_entry.options.get(
                     CONF_TEMP_TYPE,
-                    self._entry.data.get(CONF_TEMP_TYPE, CONF_TEMP_TYPE_AUTO),
+                    self.config_entry.data.get(CONF_TEMP_TYPE, CONF_TEMP_TYPE_AUTO),
                 ),
             ):
                 SelectSelector(

--- a/custom_components/hisense_aircon/const.py
+++ b/custom_components/hisense_aircon/const.py
@@ -13,6 +13,7 @@ CONF_LANIP_KEY_ID = "lanip_key_id"
 CONF_LOCAL_IP = "local_ip"
 CONF_MAC_ADDRESS = "mac_address"
 CONF_MODEL = "model"
+CONF_HUB_TYPE = "hub_type"
 CONF_SETUP_METHOD = "setup_method"
 CONF_STATUS_INTERVAL = "status_interval"
 CONF_SW_VERSION = "sw_version"
@@ -25,9 +26,11 @@ DEFAULT_STATUS_INTERVAL = 600
 SETUP_METHOD_CLOUD = "cloud"
 SETUP_METHOD_MANUAL = "manual"
 
+HUB_TYPE_CLOUD = SETUP_METHOD_CLOUD
+HUB_TYPE_MANUAL = SETUP_METHOD_MANUAL
+
 TEMP_TYPE_OPTIONS = [CONF_TEMP_TYPE_AUTO, "C", "F"]
 
-ACTIVE_CONTROLLER = "active_controller"
 VIEWS_REGISTERED = "views_registered"
 
 

--- a/custom_components/hisense_aircon/controller.py
+++ b/custom_components/hisense_aircon/controller.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .aircon import Device
 from .const import (
-    ACTIVE_CONTROLLER,
     CONF_CALLBACK_PORT,
     CONF_DEVICES,
     CONF_LOCAL_IP,
@@ -141,7 +140,6 @@ class HisenseController:
 
   def _register_views(self) -> None:
     domain_data = self.hass.data.setdefault(DOMAIN, {})
-    domain_data[ACTIVE_CONTROLLER] = self
     if domain_data.get(VIEWS_REGISTERED):
       return
     self.hass.http.register_view(HisenseKeyExchangeView())
@@ -155,9 +153,22 @@ class HisenseController:
     domain_data[VIEWS_REGISTERED] = True
 
 
+def _all_controllers(hass: HomeAssistant) -> list[HisenseController]:
+  """Return all active Hisense controllers."""
+  return [
+      controller for controller in hass.data.get(DOMAIN, {}).values()
+      if isinstance(controller, HisenseController)
+  ]
+
+
 def _controller_from_request(request: web.Request) -> HisenseController:
   hass = request.app["hass"]
-  return hass.data[DOMAIN][ACTIVE_CONTROLLER]
+  remote = request.remote
+  for controller in _all_controllers(hass):
+    if remote in controller.handlers.device_ips:
+      return controller
+  raise web.HTTPNotFound(
+      reason=f'No configured Hisense device matches request source {remote!r}.')
 
 
 def _endpoint_info(url: str, protocol_methods: list[str]) -> web.Response:
@@ -206,10 +217,13 @@ class HisenseCommandsView(HomeAssistantView):
   requires_auth = False
 
   async def get(self, request: web.Request) -> web.Response:
-    controller = _controller_from_request(request)
+    try:
+      controller = _controller_from_request(request)
+    except web.HTTPNotFound:
+      return _endpoint_info(self.url, ["GET"])
     if request.remote not in controller.handlers.device_ips:
       return _endpoint_info(self.url, ["GET"])
-    return await _controller_from_request(request).handlers.command_handler(request)
+    return await controller.handlers.command_handler(request)
 
 
 class HisenseCommandsRootView(HisenseCommandsView):

--- a/custom_components/hisense_aircon/manifest.json
+++ b/custom_components/hisense_aircon/manifest.json
@@ -13,6 +13,5 @@
     "getmac==0.9.5",
     "pycryptodome==3.23.0"
   ],
-  "single_config_entry": true,
-  "version": "1.1.7"
+  "version": "1.2.0"
 }

--- a/custom_components/hisense_aircon/strings.json
+++ b/custom_components/hisense_aircon/strings.json
@@ -63,16 +63,46 @@
           "callback_port": "Home Assistant HTTP port",
           "status_interval": "Status refresh interval"
         }
+      },
+      "reconfigure": {
+        "title": "Manage devices",
+        "description": "Add, remove, or refresh air conditioners on this integration.",
+        "data": {
+          "reconfigure_action": "Action"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Rediscover from Hisense app",
+        "description": "Re-enter your app account credentials to refresh LAN keys and find additional air conditioners. Currently configured devices stay selected even if they are no longer visible in the cloud account."
+      },
+      "reconfigure_manual": {
+        "title": "Add device manually",
+        "description": "Add another air conditioner using its LAN key and network details."
+      },
+      "reconfigure_select_devices": {
+        "title": "Select Hisense devices",
+        "description": "Choose which air conditioners to keep on this integration. At least one device must remain selected."
       }
     },
     "error": {
       "cannot_connect": "Could not connect to the Hisense/Ayla service or the credentials were rejected.",
       "device_not_found": "No matching device was found.",
       "invalid_manual_config": "Manual configuration is incomplete or invalid.",
-      "no_device_selected": "Select at least one device."
+      "no_device_selected": "Select at least one device.",
+      "duplicate_mac": "This MAC address is already configured on this integration."
     },
     "abort": {
-      "already_configured": "This device is already configured."
+      "already_configured": "This device is already configured.",
+      "reconfigure_successful": "Device configuration updated successfully."
+    }
+  },
+  "selector": {
+    "reconfigure_action": {
+      "options": {
+        "rediscover": "Rediscover from cloud account",
+        "add_manual": "Add device manually",
+        "manage": "Manage configured devices"
+      }
     }
   },
   "options": {

--- a/custom_components/hisense_aircon/strings.json
+++ b/custom_components/hisense_aircon/strings.json
@@ -10,7 +10,7 @@
       },
       "cloud": {
         "title": "Discover from Hisense app",
-        "description": "Enter the app code, username, and password for the mobile app account where your air conditioner is paired. For choosing the correct app code, see [Supported App Codes](https://github.com/cvladan/hassio-hacs-hisense-aircon#supported-app-codes). Advanced Settings are optional and can stay collapsed for most installs.",
+        "description": "Create a cloud account hub linked to your mobile app account. Devices can only be added through cloud discovery. For choosing the correct app code, see [Supported App Codes](https://github.com/cvladan/hassio-hacs-hisense-aircon#supported-app-codes). Advanced Settings are optional and can stay collapsed for most installs.",
         "data": {
           "app": "App code",
           "username": "Username",
@@ -42,13 +42,14 @@
       },
       "select_devices": {
         "title": "Select Hisense devices",
-        "description": "Choose one or more discovered air conditioners to add. All discovered devices are selected by default.",
+        "description": "Choose one or more discovered air conditioners to add to this cloud account hub. All discovered devices are selected by default.",
         "data": {
           "selected_devices": "Devices"
         }
       },
       "manual": {
         "title": "Manual LAN key setup",
+        "description": "Create a manual hub for a single air conditioner using its LAN key. To add another manual device, create another hub.",
         "data": {
           "name": "Device name",
           "app": "App code",
@@ -65,23 +66,52 @@
         }
       },
       "reconfigure": {
-        "title": "Manage devices",
-        "description": "Add, remove, or refresh air conditioners on this integration.",
+        "title": "Manage cloud account hub",
+        "description": "Rediscover devices from your app account or remove devices from this hub.",
         "data": {
           "reconfigure_action": "Action"
         }
       },
-      "reconfigure_cloud": {
-        "title": "Rediscover from Hisense app",
-        "description": "Re-enter your app account credentials to refresh LAN keys and find additional air conditioners. Currently configured devices stay selected even if they are no longer visible in the cloud account."
-      },
-      "reconfigure_manual": {
-        "title": "Add device manually",
-        "description": "Add another air conditioner using its LAN key and network details."
-      },
       "reconfigure_select_devices": {
         "title": "Select Hisense devices",
-        "description": "Choose which air conditioners to keep on this integration. At least one device must remain selected."
+        "description": "Choose which devices belong to this cloud account hub. Currently configured devices stay selected. Deselect a device to remove it from Home Assistant.",
+        "data": {
+          "selected_devices": "Devices"
+        }
+      },
+      "reconfigure_remove_devices": {
+        "title": "Remove devices",
+        "description": "Choose which devices to keep on this cloud account hub. At least one device must remain.",
+        "data": {
+          "selected_devices": "Devices to keep"
+        }
+      },
+      "reconfigure_manual": {
+        "title": "Edit manual device",
+        "description": "Update the connection details for this manual hub's device.",
+        "data": {
+          "name": "Device name",
+          "app": "App code",
+          "host": "Device IP address",
+          "mac_address": "MAC address",
+          "lanip_key": "LAN IP key",
+          "lanip_key_id": "LAN IP key ID",
+          "model": "OEM model",
+          "sw_version": "Software version",
+          "temp_type": "Temperature unit",
+          "local_ip": "Home Assistant local IP address",
+          "callback_port": "Home Assistant HTTP port",
+          "status_interval": "Status refresh interval"
+        }
+      },
+      "reauth": {
+        "title": "Update cloud account credentials",
+        "description": "Enter the current app credentials for this cloud account hub. The username must match the account already configured.",
+        "data": {
+          "app": "App code",
+          "username": "Username",
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -89,20 +119,16 @@
       "device_not_found": "No matching device was found.",
       "invalid_manual_config": "Manual configuration is incomplete or invalid.",
       "no_device_selected": "Select at least one device.",
-      "duplicate_mac": "This MAC address is already configured on this integration."
+      "duplicate_mac": "One or more selected devices are already configured in another hub.",
+      "duplicate_account": "A hub for this app account is already configured.",
+      "account_mismatch": "The username must match the cloud account already configured for this hub.",
+      "manual_single_device": "Manual hubs must contain exactly one device."
     },
     "abort": {
-      "already_configured": "This device is already configured.",
-      "reconfigure_successful": "Device configuration updated successfully."
-    }
-  },
-  "selector": {
-    "reconfigure_action": {
-      "options": {
-        "rediscover": "Rediscover from cloud account",
-        "add_manual": "Add device manually",
-        "manage": "Manage configured devices"
-      }
+      "already_configured": "This hub or device is already configured.",
+      "reconfigure_successful": "Hub configuration updated successfully.",
+      "reauth_successful": "Cloud account credentials updated successfully.",
+      "manual_single_device": "This manual hub does not contain exactly one device."
     }
   },
   "options": {

--- a/custom_components/hisense_aircon/translations/en.json
+++ b/custom_components/hisense_aircon/translations/en.json
@@ -63,16 +63,46 @@
           "callback_port": "Home Assistant HTTP port",
           "status_interval": "Status refresh interval"
         }
+      },
+      "reconfigure": {
+        "title": "Manage devices",
+        "description": "Add, remove, or refresh air conditioners on this integration.",
+        "data": {
+          "reconfigure_action": "Action"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Rediscover from Hisense app",
+        "description": "Re-enter your app account credentials to refresh LAN keys and find additional air conditioners. Currently configured devices stay selected even if they are no longer visible in the cloud account."
+      },
+      "reconfigure_manual": {
+        "title": "Add device manually",
+        "description": "Add another air conditioner using its LAN key and network details."
+      },
+      "reconfigure_select_devices": {
+        "title": "Select Hisense devices",
+        "description": "Choose which air conditioners to keep on this integration. At least one device must remain selected."
       }
     },
     "error": {
       "cannot_connect": "Could not connect to the Hisense/Ayla service or the credentials were rejected.",
       "device_not_found": "No matching device was found.",
       "invalid_manual_config": "Manual configuration is incomplete or invalid.",
-      "no_device_selected": "Select at least one device."
+      "no_device_selected": "Select at least one device.",
+      "duplicate_mac": "This MAC address is already configured on this integration."
     },
     "abort": {
-      "already_configured": "This device is already configured."
+      "already_configured": "This device is already configured.",
+      "reconfigure_successful": "Device configuration updated successfully."
+    }
+  },
+  "selector": {
+    "reconfigure_action": {
+      "options": {
+        "rediscover": "Rediscover from cloud account",
+        "add_manual": "Add device manually",
+        "manage": "Manage configured devices"
+      }
     }
   },
   "options": {

--- a/custom_components/hisense_aircon/translations/en.json
+++ b/custom_components/hisense_aircon/translations/en.json
@@ -10,7 +10,7 @@
       },
       "cloud": {
         "title": "Discover from Hisense app",
-        "description": "Enter the app code, username, and password for the mobile app account where your air conditioner is paired. For choosing the correct app code, see [Supported App Codes](https://github.com/cvladan/hassio-hacs-hisense-aircon#supported-app-codes). Advanced Settings are optional and can stay collapsed for most installs.",
+        "description": "Create a cloud account hub linked to your mobile app account. Devices can only be added through cloud discovery. For choosing the correct app code, see [Supported App Codes](https://github.com/cvladan/hassio-hacs-hisense-aircon#supported-app-codes). Advanced Settings are optional and can stay collapsed for most installs.",
         "data": {
           "app": "App code",
           "username": "Username",
@@ -42,13 +42,14 @@
       },
       "select_devices": {
         "title": "Select Hisense devices",
-        "description": "Choose one or more discovered air conditioners to add. All discovered devices are selected by default.",
+        "description": "Choose one or more discovered air conditioners to add to this cloud account hub. All discovered devices are selected by default.",
         "data": {
           "selected_devices": "Devices"
         }
       },
       "manual": {
         "title": "Manual LAN key setup",
+        "description": "Create a manual hub for a single air conditioner using its LAN key. To add another manual device, create another hub.",
         "data": {
           "name": "Device name",
           "app": "App code",
@@ -65,23 +66,52 @@
         }
       },
       "reconfigure": {
-        "title": "Manage devices",
-        "description": "Add, remove, or refresh air conditioners on this integration.",
+        "title": "Manage cloud account hub",
+        "description": "Rediscover devices from your app account or remove devices from this hub.",
         "data": {
           "reconfigure_action": "Action"
         }
       },
-      "reconfigure_cloud": {
-        "title": "Rediscover from Hisense app",
-        "description": "Re-enter your app account credentials to refresh LAN keys and find additional air conditioners. Currently configured devices stay selected even if they are no longer visible in the cloud account."
-      },
-      "reconfigure_manual": {
-        "title": "Add device manually",
-        "description": "Add another air conditioner using its LAN key and network details."
-      },
       "reconfigure_select_devices": {
         "title": "Select Hisense devices",
-        "description": "Choose which air conditioners to keep on this integration. At least one device must remain selected."
+        "description": "Choose which devices belong to this cloud account hub. Currently configured devices stay selected. Deselect a device to remove it from Home Assistant.",
+        "data": {
+          "selected_devices": "Devices"
+        }
+      },
+      "reconfigure_remove_devices": {
+        "title": "Remove devices",
+        "description": "Choose which devices to keep on this cloud account hub. At least one device must remain.",
+        "data": {
+          "selected_devices": "Devices to keep"
+        }
+      },
+      "reconfigure_manual": {
+        "title": "Edit manual device",
+        "description": "Update the connection details for this manual hub's device.",
+        "data": {
+          "name": "Device name",
+          "app": "App code",
+          "host": "Device IP address",
+          "mac_address": "MAC address",
+          "lanip_key": "LAN IP key",
+          "lanip_key_id": "LAN IP key ID",
+          "model": "OEM model",
+          "sw_version": "Software version",
+          "temp_type": "Temperature unit",
+          "local_ip": "Home Assistant local IP address",
+          "callback_port": "Home Assistant HTTP port",
+          "status_interval": "Status refresh interval"
+        }
+      },
+      "reauth": {
+        "title": "Update cloud account credentials",
+        "description": "Enter the current app credentials for this cloud account hub. The username must match the account already configured.",
+        "data": {
+          "app": "App code",
+          "username": "Username",
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -89,20 +119,16 @@
       "device_not_found": "No matching device was found.",
       "invalid_manual_config": "Manual configuration is incomplete or invalid.",
       "no_device_selected": "Select at least one device.",
-      "duplicate_mac": "This MAC address is already configured on this integration."
+      "duplicate_mac": "One or more selected devices are already configured in another hub.",
+      "duplicate_account": "A hub for this app account is already configured.",
+      "account_mismatch": "The username must match the cloud account already configured for this hub.",
+      "manual_single_device": "Manual hubs must contain exactly one device."
     },
     "abort": {
-      "already_configured": "This device is already configured.",
-      "reconfigure_successful": "Device configuration updated successfully."
-    }
-  },
-  "selector": {
-    "reconfigure_action": {
-      "options": {
-        "rediscover": "Rediscover from cloud account",
-        "add_manual": "Add device manually",
-        "manage": "Manage configured devices"
-      }
+      "already_configured": "This hub or device is already configured.",
+      "reconfigure_successful": "Hub configuration updated successfully.",
+      "reauth_successful": "Cloud account credentials updated successfully.",
+      "manual_single_device": "This manual hub does not contain exactly one device."
     }
   },
   "options": {


### PR DESCRIPTION
This adds support for adding and removing multiple AC devices.
Two kinds of HA hubs can now be setup:
1) the cloud hub - which will let the user discover and automatically add devices from a single app account.
2) the "manual" hub - which will let the user add a single device manually, by specifying all the necessary options.

**Note** that this change has been vibe-coded using CursorAI, so it might not be ideal. I lack knowledge to review the changes.
**Note** that I was not able to test the "cloud hub" mode, as the integration fails to fetch the data from my HiSmart account for some reason.